### PR TITLE
Remove ff only from merge config

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -94,7 +94,6 @@
 
 [merge]
   verbosity = 5
-  ff        = only
 
 [push]
   default = current


### PR DESCRIPTION
I'm a little less allergic to merge commits than I used to be.

This really just made me pass `-ff-only` all the time, which is more of a pain than a benefit.