### PR TITLE
Open pwd in psh if no dir specified

### DIFF
--- a/tag-wsltty/env-specific/init.sh
+++ b/tag-wsltty/env-specific/init.sh
@@ -11,5 +11,14 @@ git config --system core.autocrlf true
 
 
 psh() {
-  cmd.exe /c start powershell -noexit -command "cd $(wslpath -w $1)"
+  local psh_path
+
+  if [ "$1" = "" ]; then
+    psh_path="$(pwd)"
+  else
+    psh_path="$1"
+  fi
+
+
+  cmd.exe /c start powershell -noexit -command "cd $(wslpath -w $psh_path)"
 }


### PR DESCRIPTION
This is honestly most of the use I get out of it anyway, so it should just work.

Means I can now just type `$ psh` and have powershell open in my current directory.