### PR TITLE
Also support . with psh

### DIFF
--- a/tag-wsltty/env-specific/init.sh
+++ b/tag-wsltty/env-specific/init.sh
@@ -13,7 +13,7 @@ git config --system core.autocrlf true
 psh() {
   local psh_path
 
-  if [ "$1" = "" ]; then
+  if [ "$1" = "" ] || [ "$1" = "." ]; then
     psh_path="$(pwd)"
   else
     psh_path="$1"


### PR DESCRIPTION
Will probably find myself forgetting that no argument is required, and type `psh .`, which should also just work.