### PR TITLE
Add `packages/` to agignore

### DIFF
--- a/agignore
+++ b/agignore
@@ -1,2 +1,3 @@
 .git/
 node_modules/
+packages/


### PR DESCRIPTION
Don't need to search through NuGet deps most of the time.