### PR TITLE
misc: Add teardown.sh

### DIFF
--- a/rcrc
+++ b/rcrc
@@ -1,1 +1,1 @@
-EXCLUDES="README*.md setup.sh up.sh Shortcuts.json actions-*"
+EXCLUDES="README*.md setup.sh teardown.sh up.sh down.sh Shortcuts.json actions-*"

--- a/tag-macos/down.sh
+++ b/tag-macos/down.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dotfiles="$HOME/.dotfiles"
+tag="macos"
+
+export RCRC="$dotfiles/rcrc" && rcdn -v -d "$dotfiles" -t "$tag"

--- a/teardown.sh
+++ b/teardown.sh
@@ -30,20 +30,9 @@ ERR
   esac
 }
 
-_clone_repo() {
-  if ! [ -d "$DOTFILES" ]; then
-    git clone git@github.com:awseward/dotfiles.git "$DOTFILES"
-  else
-    echo "WARNING: Directory $DOTFILES already exists."
-
-    _prompt_yn 'Skip cloning and continue anyway' 'y' || return 1
-  fi
-}
-
-_up() {
-  "$DOTFILES/tag-$RCM_TAG/up.sh"
+_down() {
+  "$DOTFILES/tag-$RCM_TAG/down.sh"
 }
 
 _resolve_rcm_tag
-_clone_repo
-_up
+_down


### PR DESCRIPTION
Goal is to (very loosely) make the `teardown.sh` experience into a symmetric inverse of `setup.sh`.