### PR TITLE
Load passphrase from MacOS keychain

### DIFF
--- a/tag-macos/config/backups/README.md
+++ b/tag-macos/config/backups/README.md
@@ -9,7 +9,17 @@ The stuff in here is based loosely on stuff found in:
 
 ## Setup
 
+#### Add passphrase to MacOS Keychain
+
+```sh
+security add-generic-password -D secret -U -a "${USER}" -s borg-passphrase -w '<FIXME__passphrase_here>'
+```
+
 #### Initialize Remote Repo
+
+Before doing this, it's a good idea to run lines from the top of `rsync-net.sh` which export the following environment variables:
+* `BORG_PASSCOMMAND`
+* `BORG_REMOTE_PATH`
 
 ```sh
 borg init --encryption=repokey rsync-net:borg-test
@@ -23,7 +33,6 @@ Host rsync-net
   HostName <rsync_hostname>
   IdentityFile ~/.ssh/id_ed25519
 ```
-
 
 #### Place LaunchAgent
 

--- a/tag-macos/config/backups/rsync-net.sh
+++ b/tag-macos/config/backups/rsync-net.sh
@@ -6,8 +6,8 @@
 # Setting this, so the repo does not need to be given on the commandline:
 export BORG_REPO='rsync-net:borg-test'
 
-# See the section "Passphrase notes" for more infos.
-export BORG_PASSPHRASE=''
+# Load passphrase from MacOS keychain
+export BORG_PASSCOMMAND="security find-generic-password -a ${USER} -s borg-passphrase -w"
 
 # This needs to be set to use borg 1.X on rsync.net
 export BORG_REMOTE_PATH='/usr/local/bin/borg1/borg1'


### PR DESCRIPTION
This change implements `Using BORG_PASSCOMMAND with macOS Keychain` from
the following link:
https://borgbackup.readthedocs.io/en/stable/faq.html#how-can-i-specify-the-encryption-passphrase-programmatically